### PR TITLE
Wrap the with_items var ref to avoid deprecation

### DIFF
--- a/group_vars/wordpress
+++ b/group_vars/wordpress
@@ -4,4 +4,4 @@ wp_root: /srv/example.com/wordpress
 wp_db_name: example_com
 wp_db_user: example_user
 # wp_plugins:
-#   - { name: akismet, version: 3.0.1 }
+#   - { name: akismet, version: 3.1.10 }

--- a/roles/wordpress/defaults/main.yml
+++ b/roles/wordpress/defaults/main.yml
@@ -8,4 +8,4 @@ wp_debug: false
 wp_delete_content: false
 wp_lang: en_US
 wp_table_prefix: wp_
-wp_version: 3.9.2
+wp_version: 4.4.2

--- a/roles/wordpress/tasks/plugins.yml
+++ b/roles/wordpress/tasks/plugins.yml
@@ -5,6 +5,6 @@
 
 - name: Install WordPress plugins
   command: wp plugin install {{ item.name }} --version={{ item.version }} --activate --force --allow-root chdir={{ wp_root }}
-  with_items: wp_plugins
+  with_items: "{{ wp_plugins }}"
   when: wp_plugins is defined
   tags: plugins


### PR DESCRIPTION
With_items: references to a YAML list need to be wrapped with "{{}}"
